### PR TITLE
Dedup plugin

### DIFF
--- a/src/builder.js
+++ b/src/builder.js
@@ -1,6 +1,7 @@
 import {mapObject, mapValues, compose, toObject, reduce, toPairs,
         prop, filterObject, isEqual, not, curry, copyFunction} from './fp';
 import {decorator} from './decorator';
+import {dedup} from './dedup';
 
 // [[EntityName, EntityConfig]] -> Entity
 const toEntity = ([name, c]) => ({
@@ -118,5 +119,5 @@ const applyPlugin = curry((config, entityConfigs, plugin) => {
 export const build = (c, ps = []) => {
   const config = c.__config || {idField: 'id'};
   const createApi = compose(toApi, reduce(applyPlugin(config), getEntityConfigs(c)));
-  return createApi([decorator, ...ps]);
+  return createApi([decorator, ...ps, dedup]);
 };

--- a/src/dedup/index.js
+++ b/src/dedup/index.js
@@ -1,5 +1,19 @@
-export const dedup = () => ({ apiFnName, apiFn }) => {
-  if (apiFn.operation !== 'READ') {
-    return apiFn;
-  }
-}
+const toKey = (args) => JSON.stringify(args);
+
+export const dedup = () => ({ apiFn }) => {
+  if (apiFn.operation !== 'READ') { return apiFn; }
+  const cache = {};
+
+  return (...args) => {
+    const key = toKey(args);
+    const cached = cache[key];
+    if (cached) { return cached; }
+
+    const promise = apiFn(...args);
+    cache[key] = promise;
+    return promise.then((res) => {
+      delete cache[key];
+      return res;
+    });
+  };
+};

--- a/src/dedup/index.js
+++ b/src/dedup/index.js
@@ -1,10 +1,18 @@
+import { reduce } from '../fp';
+
 const toKey = (args) => JSON.stringify(args);
 
-export const dedup = () => ({ apiFn }) => {
+const isActive = reduce((active, conf = {}) => active && !conf.noDedup, true);
+
+export const dedup = ({ config }) => ({ entity, apiFn }) => {
   if (apiFn.operation !== 'READ') { return apiFn; }
   const cache = {};
 
   return (...args) => {
+    if (!isActive([config, entity, apiFn])) {
+      return apiFn(...args);
+    }
+
     const key = toKey(args);
     const cached = cache[key];
     if (cached) { return cached; }

--- a/src/dedup/index.js
+++ b/src/dedup/index.js
@@ -4,20 +4,20 @@ const toKey = (args) => JSON.stringify(args);
 
 const isActive = reduce((active, conf = {}) => active && !conf.noDedup, true);
 
-export const dedup = ({ config }) => ({ entity, apiFn }) => {
-  if (apiFn.operation !== 'READ') { return apiFn; }
+export const dedup = ({ config }) => ({ entity, fn }) => {
+  if (fn.operation !== 'READ') { return fn; }
   const cache = {};
 
   return (...args) => {
-    if (!isActive([config, entity, apiFn])) {
-      return apiFn(...args);
+    if (!isActive([config, entity, fn])) {
+      return fn(...args);
     }
 
     const key = toKey(args);
     const cached = cache[key];
     if (cached) { return cached; }
 
-    const promise = apiFn(...args);
+    const promise = fn(...args);
     cache[key] = promise;
     const cleanup = () => delete cache[key];
 

--- a/src/dedup/index.js
+++ b/src/dedup/index.js
@@ -1,0 +1,5 @@
+export const dedup = () => ({ apiFnName, apiFn }) => {
+  if (apiFn.operation !== 'READ') {
+    return apiFn;
+  }
+}

--- a/src/dedup/index.js
+++ b/src/dedup/index.js
@@ -19,9 +19,14 @@ export const dedup = ({ config }) => ({ entity, apiFn }) => {
 
     const promise = apiFn(...args);
     cache[key] = promise;
+    const cleanup = () => delete cache[key];
+
     return promise.then((res) => {
-      delete cache[key];
+      cleanup();
       return res;
+    }, (err) => {
+      cleanup();
+      return Promise.reject(err);
     });
   };
 };

--- a/src/dedup/index.spec.js
+++ b/src/dedup/index.spec.js
@@ -7,7 +7,7 @@ const delay = (cb, t = 5) => new Promise((res, rej) => {
   setTimeout(() => cb().then(res, rej), t);
 });
 
-fdescribe('dedup', () => {
+describe('dedup', () => {
   describe('for operations other than READ', () => {
     it('just returns the original apiFn', () => {
       const user = { id: 'x' };

--- a/src/dedup/index.spec.js
+++ b/src/dedup/index.spec.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-unused-expressions */
+
 import sinon from 'sinon';
 import { dedup } from '.';
 
@@ -5,11 +7,11 @@ const delay = (cb, t = 5) => new Promise((res, rej) => {
   setTimeout(() => cb().then(res, rej), t);
 });
 
-describe('dedup', () => {
+fdescribe('dedup', () => {
   describe('for operations other than READ', () => {
     it('just returns the original apiFn', () => {
       const user = { id: 'x' };
-      const apiFn = sinon.spy(() => Promise.resolve(user));
+      const apiFn = sinon.spy(() => Promise.resolve({ ...user }));
       apiFn.operation = 'UPDATE';
       const wrappedApiFn = dedup({})({ apiFn, apiFnName: 'apiFn' });
       expect(wrappedApiFn).to.equal(apiFn);
@@ -27,53 +29,54 @@ describe('dedup', () => {
 
     it('makes several calls when apiFn is called with different args', () => {
       const user = { id: 'x' };
-      const apiFn = sinon.spy(() => Promise.resolve(user));
+      const apiFn = sinon.spy(() => Promise.resolve({ ...user }));
       apiFn.operation = 'READ';
       const wrappedApiFn = dedup({})({ apiFn, apiFnName: 'apiFn' });
       return Promise.all([
         wrappedApiFn('x'),
         wrappedApiFn('y')
       ]).then(() => {
-        expect(wrappedApiFn).to.have.been.calledTwice();
+        expect(apiFn).to.have.been.calledTwice;
       });
     });
 
     it('only makes one call when apiFn is called in identical args', () => {
       const user = { id: 'x' };
-      const apiFn = sinon.spy(delay(() => Promise.resolve(user)));
+      const apiFn = sinon.spy(() => delay(() => Promise.resolve({ ...user })));
       apiFn.operation = 'READ';
       const wrappedApiFn = dedup({})({ apiFn, apiFnName: 'apiFn' });
       return Promise.all([
         wrappedApiFn('x'),
         wrappedApiFn('x')
       ]).then(() => {
-        expect(wrappedApiFn).to.have.been.calledOnce();
+        expect(apiFn).to.have.been.calledOnce;
       });
     });
 
     it('passes the result of the single call to all callees', () => {
       const user = { id: 'x' };
-      const apiFn = sinon.spy(delay(() => Promise.resolve(user)));
+      const apiFn = sinon.spy(() => delay(() => Promise.resolve({ ...user })));
       apiFn.operation = 'READ';
       const wrappedApiFn = dedup({})({ apiFn, apiFnName: 'apiFn' });
       return Promise.all([
         wrappedApiFn(),
         wrappedApiFn()
       ]).then((res) => {
-        expect(res[0]).to.equal(user);
-        expect(res[1]).to.equal(user);
+        expect(res[0]).to.deep.equal(user);
+        expect(res[1]).to.deep.equal(user);
+        expect(res[0]).to.equal(res[1]);
       });
     });
 
     it('makes subsequent calls if another calls is made after the first one is resolved', () => {
       const user = { id: 'x' };
-      const apiFn = sinon.spy(delay(() => Promise.resolve(user)));
+      const apiFn = sinon.spy(() => delay(() => Promise.resolve({ ...user })));
       apiFn.operation = 'READ';
       const wrappedApiFn = dedup({})({ apiFn, apiFnName: 'apiFn' });
 
       return wrappedApiFn().then(() => {
         return wrappedApiFn().then(() => {
-          expect(wrappedApiFn).to.have.been.calledTwice();
+          expect(apiFn).to.have.been.calledTwice;
         });
       });
     });

--- a/src/dedup/index.spec.js
+++ b/src/dedup/index.spec.js
@@ -53,6 +53,19 @@ describe('dedup', () => {
       });
     });
 
+    it('detects complex arguments properly', () => {
+      const user = { id: 'x' };
+      const apiFn = sinon.spy(() => delay(() => Promise.resolve({ ...user })));
+      apiFn.operation = 'READ';
+      const wrappedApiFn = dedup({})({ apiFn });
+      return Promise.all([
+        wrappedApiFn({ a: 1, b: [2, 3] }, 'a'),
+        wrappedApiFn({ a: 1, b: [2, 3] }, 'a')
+      ]).then(() => {
+        expect(apiFn).to.have.been.calledOnce;
+      });
+    });
+
     it('passes the result of the single call to all callees', () => {
       const user = { id: 'x' };
       const apiFn = sinon.spy(() => delay(() => Promise.resolve({ ...user })));

--- a/src/dedup/index.spec.js
+++ b/src/dedup/index.spec.js
@@ -93,5 +93,50 @@ fdescribe('dedup', () => {
         expect(res[0]).to.equal(res[1]);
       });
     });
+
+    it('can be disabled on a global level', () => {
+      const user = { id: 'x' };
+      const apiFn = sinon.spy(() => delay(() => Promise.resolve({ ...user })));
+      apiFn.operation = 'READ';
+      const config = { noDedup: true };
+      const wrappedApiFn = dedup({ config })({ apiFn });
+
+      return Promise.all([
+        wrappedApiFn(),
+        wrappedApiFn()
+      ]).then(() => {
+        expect(apiFn).to.have.been.calledTwice;
+      });
+    });
+
+    it('can be disabled on an entity level', () => {
+      const user = { id: 'x' };
+      const apiFn = sinon.spy(() => delay(() => Promise.resolve({ ...user })));
+      apiFn.operation = 'READ';
+      const entity = { noDedup: true };
+      const wrappedApiFn = dedup({})({ apiFn, entity });
+
+      return Promise.all([
+        wrappedApiFn(),
+        wrappedApiFn()
+      ]).then(() => {
+        expect(apiFn).to.have.been.calledTwice;
+      });
+    });
+
+    it('can be disabled on a function level', () => {
+      const user = { id: 'x' };
+      const apiFn = sinon.spy(() => delay(() => Promise.resolve({ ...user })));
+      apiFn.operation = 'READ';
+      apiFn.noDedup = true;
+      const wrappedApiFn = dedup({})({ apiFn });
+
+      return Promise.all([
+        wrappedApiFn(),
+        wrappedApiFn()
+      ]).then(() => {
+        expect(apiFn).to.have.been.calledTwice;
+      });
+    });
   });
 });

--- a/src/dedup/index.spec.js
+++ b/src/dedup/index.spec.js
@@ -11,66 +11,66 @@ describe('dedup', () => {
   describe('for operations other than READ', () => {
     it('just returns the original apiFn', () => {
       const user = { id: 'x' };
-      const apiFn = sinon.spy(() => Promise.resolve({ ...user }));
-      apiFn.operation = 'UPDATE';
-      const wrappedApiFn = dedup({})({ apiFn });
-      expect(wrappedApiFn).to.equal(apiFn);
+      const fn = sinon.spy(() => Promise.resolve({ ...user }));
+      fn.operation = 'UPDATE';
+      const wrappedApiFn = dedup({})({ fn });
+      expect(wrappedApiFn).to.equal(fn);
     });
   });
 
   describe('for READ operations', () => {
     it('wraps the function', () => {
       const user = { id: 'x' };
-      const apiFn = sinon.spy(() => Promise.resolve(user));
-      apiFn.operation = 'READ';
-      const wrappedApiFn = dedup({})({ apiFn });
-      expect(wrappedApiFn).not.to.equal(apiFn);
+      const fn = sinon.spy(() => Promise.resolve(user));
+      fn.operation = 'READ';
+      const wrappedApiFn = dedup({})({ fn });
+      expect(wrappedApiFn).not.to.equal(fn);
     });
 
     it('makes several calls when apiFn is called with different args', () => {
       const user = { id: 'x' };
-      const apiFn = sinon.spy(() => Promise.resolve({ ...user }));
-      apiFn.operation = 'READ';
-      const wrappedApiFn = dedup({})({ apiFn });
+      const fn = sinon.spy(() => Promise.resolve({ ...user }));
+      fn.operation = 'READ';
+      const wrappedApiFn = dedup({})({ fn });
       return Promise.all([
         wrappedApiFn('x'),
         wrappedApiFn('y')
       ]).then(() => {
-        expect(apiFn).to.have.been.calledTwice;
+        expect(fn).to.have.been.calledTwice;
       });
     });
 
     it('only makes one call when apiFn is called in identical args', () => {
       const user = { id: 'x' };
-      const apiFn = sinon.spy(() => delay(() => Promise.resolve({ ...user })));
-      apiFn.operation = 'READ';
-      const wrappedApiFn = dedup({})({ apiFn });
+      const fn = sinon.spy(() => delay(() => Promise.resolve({ ...user })));
+      fn.operation = 'READ';
+      const wrappedApiFn = dedup({})({ fn });
       return Promise.all([
         wrappedApiFn('x'),
         wrappedApiFn('x')
       ]).then(() => {
-        expect(apiFn).to.have.been.calledOnce;
+        expect(fn).to.have.been.calledOnce;
       });
     });
 
     it('detects complex arguments properly', () => {
       const user = { id: 'x' };
-      const apiFn = sinon.spy(() => delay(() => Promise.resolve({ ...user })));
-      apiFn.operation = 'READ';
-      const wrappedApiFn = dedup({})({ apiFn });
+      const fn = sinon.spy(() => delay(() => Promise.resolve({ ...user })));
+      fn.operation = 'READ';
+      const wrappedApiFn = dedup({})({ fn });
       return Promise.all([
         wrappedApiFn({ a: 1, b: [2, 3] }, 'a'),
         wrappedApiFn({ a: 1, b: [2, 3] }, 'a')
       ]).then(() => {
-        expect(apiFn).to.have.been.calledOnce;
+        expect(fn).to.have.been.calledOnce;
       });
     });
 
     it('passes the result of the single call to all callees', () => {
       const user = { id: 'x' };
-      const apiFn = sinon.spy(() => delay(() => Promise.resolve({ ...user })));
-      apiFn.operation = 'READ';
-      const wrappedApiFn = dedup({})({ apiFn });
+      const fn = sinon.spy(() => delay(() => Promise.resolve({ ...user })));
+      fn.operation = 'READ';
+      const wrappedApiFn = dedup({})({ fn });
       return Promise.all([
         wrappedApiFn(),
         wrappedApiFn()
@@ -83,34 +83,34 @@ describe('dedup', () => {
 
     it('makes subsequent calls if another calls is made after the first one is resolved', () => {
       const user = { id: 'x' };
-      const apiFn = sinon.spy(() => delay(() => Promise.resolve({ ...user })));
-      apiFn.operation = 'READ';
-      const wrappedApiFn = dedup({})({ apiFn });
+      const fn = sinon.spy(() => delay(() => Promise.resolve({ ...user })));
+      fn.operation = 'READ';
+      const wrappedApiFn = dedup({})({ fn });
 
       return wrappedApiFn().then(() => {
         return wrappedApiFn().then(() => {
-          expect(apiFn).to.have.been.calledTwice;
+          expect(fn).to.have.been.calledTwice;
         });
       });
     });
 
     it('also makes subsequent calls after the first one is rejected', () => {
       const user = { id: 'x' };
-      const apiFn = sinon.spy(() => delay(() => Promise.reject({ ...user })));
-      apiFn.operation = 'READ';
-      const wrappedApiFn = dedup({})({ apiFn });
+      const fn = sinon.spy(() => delay(() => Promise.reject({ ...user })));
+      fn.operation = 'READ';
+      const wrappedApiFn = dedup({})({ fn });
 
       return wrappedApiFn().catch(() => {
         return wrappedApiFn().catch(() => {
-          expect(apiFn).to.have.been.calledTwice;
+          expect(fn).to.have.been.calledTwice;
         });
       });
     });
 
     it('propagates errors to all callees', () => {
       const error = { error: 'ERROR' };
-      const apiFn = sinon.spy(() => delay(() => Promise.reject(error)));
-      const wrappedApiFn = dedup({})({ apiFn });
+      const fn = sinon.spy(() => delay(() => Promise.reject(error)));
+      const wrappedApiFn = dedup({})({ fn });
       return Promise.all([
         wrappedApiFn().catch((err) => err),
         wrappedApiFn().catch((err) => err)
@@ -122,46 +122,46 @@ describe('dedup', () => {
 
     it('can be disabled on a global level', () => {
       const user = { id: 'x' };
-      const apiFn = sinon.spy(() => delay(() => Promise.resolve({ ...user })));
-      apiFn.operation = 'READ';
+      const fn = sinon.spy(() => delay(() => Promise.resolve({ ...user })));
+      fn.operation = 'READ';
       const config = { noDedup: true };
-      const wrappedApiFn = dedup({ config })({ apiFn });
+      const wrappedApiFn = dedup({ config })({ fn });
 
       return Promise.all([
         wrappedApiFn(),
         wrappedApiFn()
       ]).then(() => {
-        expect(apiFn).to.have.been.calledTwice;
+        expect(fn).to.have.been.calledTwice;
       });
     });
 
     it('can be disabled on an entity level', () => {
       const user = { id: 'x' };
-      const apiFn = sinon.spy(() => delay(() => Promise.resolve({ ...user })));
-      apiFn.operation = 'READ';
+      const fn = sinon.spy(() => delay(() => Promise.resolve({ ...user })));
+      fn.operation = 'READ';
       const entity = { noDedup: true };
-      const wrappedApiFn = dedup({})({ apiFn, entity });
+      const wrappedApiFn = dedup({})({ fn, entity });
 
       return Promise.all([
         wrappedApiFn(),
         wrappedApiFn()
       ]).then(() => {
-        expect(apiFn).to.have.been.calledTwice;
+        expect(fn).to.have.been.calledTwice;
       });
     });
 
     it('can be disabled on a function level', () => {
       const user = { id: 'x' };
-      const apiFn = sinon.spy(() => delay(() => Promise.resolve({ ...user })));
-      apiFn.operation = 'READ';
-      apiFn.noDedup = true;
-      const wrappedApiFn = dedup({})({ apiFn });
+      const fn = sinon.spy(() => delay(() => Promise.resolve({ ...user })));
+      fn.operation = 'READ';
+      fn.noDedup = true;
+      const wrappedApiFn = dedup({})({ fn });
 
       return Promise.all([
         wrappedApiFn(),
         wrappedApiFn()
       ]).then(() => {
-        expect(apiFn).to.have.been.calledTwice;
+        expect(fn).to.have.been.calledTwice;
       });
     });
   });

--- a/src/dedup/index.spec.js
+++ b/src/dedup/index.spec.js
@@ -13,7 +13,7 @@ fdescribe('dedup', () => {
       const user = { id: 'x' };
       const apiFn = sinon.spy(() => Promise.resolve({ ...user }));
       apiFn.operation = 'UPDATE';
-      const wrappedApiFn = dedup({})({ apiFn, apiFnName: 'apiFn' });
+      const wrappedApiFn = dedup({})({ apiFn });
       expect(wrappedApiFn).to.equal(apiFn);
     });
   });
@@ -23,7 +23,7 @@ fdescribe('dedup', () => {
       const user = { id: 'x' };
       const apiFn = sinon.spy(() => Promise.resolve(user));
       apiFn.operation = 'READ';
-      const wrappedApiFn = dedup({})({ apiFn, apiFnName: 'apiFn' });
+      const wrappedApiFn = dedup({})({ apiFn });
       expect(wrappedApiFn).not.to.equal(apiFn);
     });
 
@@ -31,7 +31,7 @@ fdescribe('dedup', () => {
       const user = { id: 'x' };
       const apiFn = sinon.spy(() => Promise.resolve({ ...user }));
       apiFn.operation = 'READ';
-      const wrappedApiFn = dedup({})({ apiFn, apiFnName: 'apiFn' });
+      const wrappedApiFn = dedup({})({ apiFn });
       return Promise.all([
         wrappedApiFn('x'),
         wrappedApiFn('y')
@@ -44,7 +44,7 @@ fdescribe('dedup', () => {
       const user = { id: 'x' };
       const apiFn = sinon.spy(() => delay(() => Promise.resolve({ ...user })));
       apiFn.operation = 'READ';
-      const wrappedApiFn = dedup({})({ apiFn, apiFnName: 'apiFn' });
+      const wrappedApiFn = dedup({})({ apiFn });
       return Promise.all([
         wrappedApiFn('x'),
         wrappedApiFn('x')
@@ -57,7 +57,7 @@ fdescribe('dedup', () => {
       const user = { id: 'x' };
       const apiFn = sinon.spy(() => delay(() => Promise.resolve({ ...user })));
       apiFn.operation = 'READ';
-      const wrappedApiFn = dedup({})({ apiFn, apiFnName: 'apiFn' });
+      const wrappedApiFn = dedup({})({ apiFn });
       return Promise.all([
         wrappedApiFn(),
         wrappedApiFn()
@@ -72,7 +72,7 @@ fdescribe('dedup', () => {
       const user = { id: 'x' };
       const apiFn = sinon.spy(() => delay(() => Promise.resolve({ ...user })));
       apiFn.operation = 'READ';
-      const wrappedApiFn = dedup({})({ apiFn, apiFnName: 'apiFn' });
+      const wrappedApiFn = dedup({})({ apiFn });
 
       return wrappedApiFn().then(() => {
         return wrappedApiFn().then(() => {
@@ -84,7 +84,7 @@ fdescribe('dedup', () => {
     it('propagates errors to all callees', () => {
       const error = { error: 'ERROR' };
       const apiFn = sinon.spy(() => delay(() => Promise.reject(error)));
-      const wrappedApiFn = dedup({})({ apiFn, apiFnName: 'apiFn' });
+      const wrappedApiFn = dedup({})({ apiFn });
       return Promise.all([
         wrappedApiFn().catch((err) => err),
         wrappedApiFn().catch((err) => err)

--- a/src/dedup/index.spec.js
+++ b/src/dedup/index.spec.js
@@ -94,6 +94,19 @@ describe('dedup', () => {
       });
     });
 
+    it('also makes subsequent calls after the first one is rejected', () => {
+      const user = { id: 'x' };
+      const apiFn = sinon.spy(() => delay(() => Promise.reject({ ...user })));
+      apiFn.operation = 'READ';
+      const wrappedApiFn = dedup({})({ apiFn });
+
+      return wrappedApiFn().catch(() => {
+        return wrappedApiFn().catch(() => {
+          expect(apiFn).to.have.been.calledTwice;
+        });
+      });
+    });
+
     it('propagates errors to all callees', () => {
       const error = { error: 'ERROR' };
       const apiFn = sinon.spy(() => delay(() => Promise.reject(error)));

--- a/src/dedup/index.spec.js
+++ b/src/dedup/index.spec.js
@@ -10,6 +10,7 @@ describe('dedup', () => {
     it('just returns the original apiFn', () => {
       const user = { id: 'x' };
       const apiFn = sinon.spy(() => Promise.resolve(user));
+      apiFn.operation = 'UPDATE';
       const wrappedApiFn = dedup({})({ apiFn, apiFnName: 'apiFn' });
       expect(wrappedApiFn).to.equal(apiFn);
     });
@@ -19,6 +20,7 @@ describe('dedup', () => {
     it('wraps the function', () => {
       const user = { id: 'x' };
       const apiFn = sinon.spy(() => Promise.resolve(user));
+      apiFn.operation = 'READ';
       const wrappedApiFn = dedup({})({ apiFn, apiFnName: 'apiFn' });
       expect(wrappedApiFn).not.to.equal(apiFn);
     });
@@ -26,6 +28,7 @@ describe('dedup', () => {
     it('makes several calls when apiFn is called with different args', () => {
       const user = { id: 'x' };
       const apiFn = sinon.spy(() => Promise.resolve(user));
+      apiFn.operation = 'READ';
       const wrappedApiFn = dedup({})({ apiFn, apiFnName: 'apiFn' });
       return Promise.all([
         wrappedApiFn('x'),
@@ -38,6 +41,7 @@ describe('dedup', () => {
     it('only makes one call when apiFn is called in identical args', () => {
       const user = { id: 'x' };
       const apiFn = sinon.spy(delay(() => Promise.resolve(user)));
+      apiFn.operation = 'READ';
       const wrappedApiFn = dedup({})({ apiFn, apiFnName: 'apiFn' });
       return Promise.all([
         wrappedApiFn('x'),
@@ -50,6 +54,7 @@ describe('dedup', () => {
     it('passes the result of the single call to all callees', () => {
       const user = { id: 'x' };
       const apiFn = sinon.spy(delay(() => Promise.resolve(user)));
+      apiFn.operation = 'READ';
       const wrappedApiFn = dedup({})({ apiFn, apiFnName: 'apiFn' });
       return Promise.all([
         wrappedApiFn(),
@@ -63,6 +68,7 @@ describe('dedup', () => {
     it('makes subsequent calls if another calls is made after the first one is resolved', () => {
       const user = { id: 'x' };
       const apiFn = sinon.spy(delay(() => Promise.resolve(user)));
+      apiFn.operation = 'READ';
       const wrappedApiFn = dedup({})({ apiFn, apiFnName: 'apiFn' });
 
       return wrappedApiFn().then(() => {

--- a/src/dedup/index.spec.js
+++ b/src/dedup/index.spec.js
@@ -81,10 +81,17 @@ fdescribe('dedup', () => {
       });
     });
 
-    // it('propagates errors to all callees', () => {
-    //   const user = { id: 'x' };
-    //   const apiFn = sinon.spy(delay(() => Promise.reject(user)));
-    //   const wrappedApiFn = dedup({})({ apiFn, apiFnName: 'apiFn' });
-    // });
+    it('propagates errors to all callees', () => {
+      const error = { error: 'ERROR' };
+      const apiFn = sinon.spy(() => delay(() => Promise.reject(error)));
+      const wrappedApiFn = dedup({})({ apiFn, apiFnName: 'apiFn' });
+      return Promise.all([
+        wrappedApiFn().catch((err) => err),
+        wrappedApiFn().catch((err) => err)
+      ]).then((res) => {
+        expect(res[0]).to.equal(error);
+        expect(res[0]).to.equal(res[1]);
+      });
+    });
   });
 });

--- a/src/dedup/index.spec.js
+++ b/src/dedup/index.spec.js
@@ -1,0 +1,81 @@
+import sinon from 'sinon';
+import { dedup } from '.';
+
+const delay = (cb, t = 5) => new Promise((res, rej) => {
+  setTimeout(() => cb().then(res, rej), t);
+});
+
+describe('dedup', () => {
+  describe('for operations other than READ', () => {
+    it('just returns the original apiFn', () => {
+      const user = { id: 'x' };
+      const apiFn = sinon.spy(() => Promise.resolve(user));
+      const wrappedApiFn = dedup({})({ apiFn, apiFnName: 'apiFn' });
+      expect(wrappedApiFn).to.equal(apiFn);
+    });
+  });
+
+  describe('for READ operations', () => {
+    it('wraps the function', () => {
+      const user = { id: 'x' };
+      const apiFn = sinon.spy(() => Promise.resolve(user));
+      const wrappedApiFn = dedup({})({ apiFn, apiFnName: 'apiFn' });
+      expect(wrappedApiFn).not.to.equal(apiFn);
+    });
+
+    it('makes several calls when apiFn is called with different args', () => {
+      const user = { id: 'x' };
+      const apiFn = sinon.spy(() => Promise.resolve(user));
+      const wrappedApiFn = dedup({})({ apiFn, apiFnName: 'apiFn' });
+      return Promise.all([
+        wrappedApiFn('x'),
+        wrappedApiFn('y')
+      ]).then(() => {
+        expect(wrappedApiFn).to.have.been.calledTwice();
+      });
+    });
+
+    it('only makes one call when apiFn is called in identical args', () => {
+      const user = { id: 'x' };
+      const apiFn = sinon.spy(delay(() => Promise.resolve(user)));
+      const wrappedApiFn = dedup({})({ apiFn, apiFnName: 'apiFn' });
+      return Promise.all([
+        wrappedApiFn('x'),
+        wrappedApiFn('x')
+      ]).then(() => {
+        expect(wrappedApiFn).to.have.been.calledOnce();
+      });
+    });
+
+    it('passes the result of the single call to all callees', () => {
+      const user = { id: 'x' };
+      const apiFn = sinon.spy(delay(() => Promise.resolve(user)));
+      const wrappedApiFn = dedup({})({ apiFn, apiFnName: 'apiFn' });
+      return Promise.all([
+        wrappedApiFn(),
+        wrappedApiFn()
+      ]).then((res) => {
+        expect(res[0]).to.equal(user);
+        expect(res[1]).to.equal(user);
+      });
+    });
+
+    it('makes subsequent calls if another calls is made after the first one is resolved', () => {
+      const user = { id: 'x' };
+      const apiFn = sinon.spy(delay(() => Promise.resolve(user)));
+      const wrappedApiFn = dedup({})({ apiFn, apiFnName: 'apiFn' });
+
+      return wrappedApiFn().then(() => {
+        return wrappedApiFn().then(() => {
+          expect(wrappedApiFn).to.have.been.calledTwice();
+        });
+      });
+    });
+
+    // it('propagates errors to all callees', () => {
+    //   const user = { id: 'x' };
+    //   const apiFn = sinon.spy(delay(() => Promise.reject(user)));
+    //   const wrappedApiFn = dedup({})({ apiFn, apiFnName: 'apiFn' });
+    // });
+  });
+});


### PR DESCRIPTION
Simple plugin to deduplicate identical requests. Makes sure that when an api function is called with identical arguments in rapid succession, only one api call is made - both all calls will receive the proper result in return.

Only operates on `READ` operations. Argument equality is established with a simple `JSON.stringify` which might not be perfect, but is most likely good enough.
Can be disabled on a global, an entity or apiFn level by adding `noDedup = true`. Check the specs for examples.

While this is implemented as a plugin as well, this is an addition to the core functionality, as discussed with @petercrona.
This plugin sits at the very end of the plugin chain - this chain currently is `[laddaCore, ...customPlugins, dedup]`. This is useful because all other plugins will also benefit from this.

Let's think of the denormalization plugin as example: This plugin makes a request and does additional operations on them (potentially makes further requests, denormalizes receiving entities). With `dedup` sitting at the end of the chain (remember that Ladda's api object is constructed inside out, which means that the dedup plugin is the first plugin to be called when an api function is triggered), this plugin also needs to do its work once: Call is made once, everything denormalized and this result is then passed on to all identical callers. 