### PR TITLE
byIds

### DIFF
--- a/src/builder.js
+++ b/src/builder.js
@@ -81,7 +81,8 @@ const setApiConfigDefaults = ec => {
     operation: 'NO_OPERATION',
     invalidates: [],
     idFrom: 'ENTITY',
-    byId: false
+    byId: false,
+    byIds: false
   };
 
   const writeToObjectIfNotSet = curry((o, [k, v]) => {

--- a/src/decorator/read.js
+++ b/src/decorator/read.js
@@ -1,12 +1,13 @@
 import {get as getFromEs,
         put as putInEs,
+        mPut as mPutInEs,
         contains as inEs} from '../entity-store';
 import {get as getFromQc,
         invalidate,
         put as putInQc,
         contains as inQc,
         getValue} from '../query-cache';
-import {passThrough, compose} from '../fp';
+import {passThrough, compose, curry, reduce, toIdMap, map, concat, zip} from '../fp';
 import {addId, removeId} from '../id-helper';
 
 const getTtl = e => e.ttl * 1000;
@@ -16,18 +17,55 @@ const hasExpired = (e, timestamp) => {
   return (Date.now() - timestamp) > getTtl(e);
 };
 
+const readFromCache = curry((es, e, aFn, id) => {
+  if (inEs(es, e, id) && !aFn.alwaysGetFreshData) {
+    const v = getFromEs(es, e, id);
+    if (!hasExpired(e, v.timestamp)) {
+      return removeId(v.value);
+    }
+  }
+  return undefined;
+});
+
 const decorateReadSingle = (c, es, qc, e, aFn) => {
   return (id) => {
-    if (inEs(es, e, id) && !aFn.alwaysGetFreshData) {
-      const v = getFromEs(es, e, id);
-      if (!hasExpired(e, v.timestamp)) {
-        return Promise.resolve(removeId(v.value));
-      }
+    const fromCache = readFromCache(es, e, aFn, id);
+    if (fromCache) {
+      return Promise.resolve(fromCache);
     }
 
     return aFn(id)
       .then(passThrough(compose(putInEs(es, e), addId(c, aFn, id))))
       .then(passThrough(() => invalidate(qc, e, aFn)));
+  };
+};
+
+const decorateReadSome = (c, es, qc, e, aFn) => {
+  return (ids) => {
+    const readFromCache_ = readFromCache(es, e, aFn);
+    const [cached, remaining] = reduce(([c_, r], id) => {
+      const fromCache = readFromCache_(id);
+      if (fromCache) {
+        c_.push(fromCache);
+      } else {
+        r.push(id);
+      }
+      return [c_, r];
+    }, [[], []], ids);
+
+    if (!remaining.length) {
+      return Promise.resolve(cached);
+    }
+
+    const addIds = map(([id, item]) => addId(c, aFn, id, item));
+
+    return aFn(remaining)
+      .then(passThrough(compose(mPutInEs(es, e), addIds, zip(remaining))))
+      .then(passThrough(() => invalidate(qc, e, aFn)))
+      .then((other) => {
+        const asMap = compose(toIdMap, concat)(cached, other);
+        return map((id) => asMap[id], ids);
+      });
   };
 };
 
@@ -49,6 +87,9 @@ const decorateReadQuery = (c, es, qc, e, aFn) => {
 export function decorateRead(c, es, qc, e, aFn) {
   if (aFn.byId) {
     return decorateReadSingle(c, es, qc, e, aFn);
+  }
+  if (aFn.byIds) {
+    return decorateReadSome(c, es, qc, e, aFn);
   }
   return decorateReadQuery(c, es, qc, e, aFn);
 }

--- a/src/decorator/read.spec.js
+++ b/src/decorator/read.spec.js
@@ -79,7 +79,7 @@ describe('Read', () => {
         done();
       });
     });
-    fdescribe('with byIds', () => {
+    describe('with byIds', () => {
       const users = {
         a: { id: 'a' },
         b: { id: 'b' },

--- a/src/entity-store.js
+++ b/src/entity-store.js
@@ -97,6 +97,9 @@ const setViewValue = (s, e, v) => {
 // EntityStore -> Entity -> Value -> ()
 export const put = handle(setViewValue, setEntityValue);
 
+// EntityStore -> Entity -> [Value] -> ()
+export const mPut = curry((es, e) => map_(put(es, e)));
+
 // EntityStore -> Entity -> String -> Value
 const getEntityValue = (s, e, id) => {
   const k = createEntityKey(e, {__ladda__id: id});

--- a/src/fp.js
+++ b/src/fp.js
@@ -182,3 +182,5 @@ export const uniq = (arr) => [...new Set(arr)];
 export const fst = (arr) => arr[0];
 export const snd = (arr) => arr[1];
 
+export const toIdMap = toObject(prop('id'));
+

--- a/src/fp.spec.js
+++ b/src/fp.spec.js
@@ -6,7 +6,7 @@ import {debug, identity, curry, passThrough,
         on2, init, tail, last, head, map, map_, reverse,
         reduce, compose, prop, zip, flip, toPairs, fromPairs,
         mapObject, mapValues, toObject, filter, clone, filterObject,
-        copyFunction, get, set, concat, flatten, uniq} from './fp';
+        copyFunction, get, set, concat, flatten, uniq, toIdMap} from './fp';
 
 describe('fp', () => {
   describe('debug', () => {
@@ -344,6 +344,18 @@ describe('fp', () => {
       const list = [a, a, b, a, b, a];
       const expected = [a, b];
       const actual = uniq(list);
+      expect(actual).to.deep.equal(expected);
+    });
+  });
+
+  describe('toIdMap', () => {
+    it('returns a map with ids as keys from a list of entities', () => {
+      const a = { id: 'a' };
+      const b = { id: 'b' };
+      const c = { id: 'c' };
+
+      const expected = { a, b, c };
+      const actual = toIdMap([a, b, c]);
       expect(actual).to.deep.equal(expected);
     });
   });

--- a/src/plugins/denormalizer/index.js
+++ b/src/plugins/denormalizer/index.js
@@ -1,7 +1,7 @@
 import {
   compose, curry, head, map, mapObject, mapValues,
-  prop, reduce, fromPairs, toPairs, toObject, values,
-  uniq, flatten, get, set, snd
+  prop, reduce, fromPairs, toPairs, values,
+  uniq, flatten, get, set, snd, toIdMap
 } from '../../fp';
 
 /* TYPES
@@ -22,8 +22,6 @@ import {
 export const NAME = 'denormalizer';
 
 const def = curry((a, b) => b || a);
-
-const toIdMap = toObject(prop('id'));
 
 const getApi = curry((configs, entityName) => compose(prop('api'), prop(entityName))(configs));
 

--- a/src/plugins/denormalizer/index.spec.js
+++ b/src/plugins/denormalizer/index.spec.js
@@ -3,10 +3,8 @@
 import sinon from 'sinon';
 
 import { build } from '../../builder';
-import { curry, prop, head, last, toObject, values } from '../../fp';
+import { curry, head, last, toIdMap, values } from '../../fp';
 import { denormalizer, extractAccessors } from '.';
-
-const toIdMap = toObject(prop('id'));
 
 const peter = { id: 'peter' };
 const gernot = { id: 'gernot' };

--- a/src/test-helper.js
+++ b/src/test-helper.js
@@ -6,6 +6,7 @@ export const createApiFunction = (fn, config = {}) => {
   fnCopy.invalidates = config.invalidates || [];
   fnCopy.idFrom = config.idFrom || 'ENTITY';
   fnCopy.byId = config.byId || false;
+  fnCopy.byIds = config.byIds || false;
   return fnCopy;
 };
 


### PR DESCRIPTION
Adds a `byIds` apiFn config option, which is the same as `byId`, just working on a list of ids.
It's speciality is that it will only make a request for items which are not present in the cache.
Asking for `[1, 2, 3]` when 1 and 2 are already cached will only make a call for `[3]`.